### PR TITLE
uplevel for 2026 tech stack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 plugins {
     id "java"
-    id 'org.springframework.boot' version '3.2.3'
+    id 'org.springframework.boot' version '4.0.0'
 }
 
 apply plugin: 'io.spring.dependency-management'
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(25))
     }
 }
 
@@ -17,7 +17,8 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")    // web communication
-    implementation('org.springframework.boot:spring-boot-starter-test')   // unit tests that work with MVC
+    implementation('org.springframework.boot:spring-boot-starter-test')   // unit tests
+    implementation('org.springframework.boot:spring-boot-starter-webmvc-test') // MVC unit tests
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/java/com/acme/statusmgr/StatusControllerBasicTest.java
+++ b/src/test/java/com/acme/statusmgr/StatusControllerBasicTest.java
@@ -2,7 +2,7 @@ package com.acme.statusmgr;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 

--- a/src/test/java/com/acme/statusmgr/StatusControllerDetailedTest.java
+++ b/src/test/java/com/acme/statusmgr/StatusControllerDetailedTest.java
@@ -19,7 +19,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 


### PR DESCRIPTION
Uplevel Java from 17 to 25, which reqs Spring upleveled from 3.x to 4 - required use of new MVC Mock components.  Also uplevel gradle from 8.x to 9.3.1